### PR TITLE
Refactor App Component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,7 @@
+//App.tsx
 import './App.css';
 
-import {
-  type MutableRefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Board } from './components/Board';
 import { BoardHeader } from './components/BoardHeader';
@@ -23,85 +18,18 @@ import {
   moveUp,
 } from './utils/gameLogic';
 
-type PrevState = {
-  grid: number[][];
-  score: number;
-};
 function App() {
-  const [grid, setGrid] = usePersistedState('grid', initializeGrid());
-
-  // 리로딩 할때 점수 유지
-  const [score, setScore] = usePersistedState('currentScore', 0);
-
-  const scoreRef = useRef<number>(score); // re-rendering 없이 점수 store
-
-  const [bestScore, setBestScore] = usePersistedState('bestScore', 0);
-
-  // undo 기능을 위한 prev Tracking
-  const [history, setHistory] = usePersistedState<PrevState[]>('history', []);
-
-  const undoCallback = useCallback(() => {
-    undo(history, setGrid, setScore, scoreRef, setHistory);
-  }, [history, setGrid, setScore, setHistory]);
-
-  const resetGameCallback = () => {
-    resetGame(setGrid, scoreRef, setScore, setHistory);
-  };
-
-  // 점수 바뀔 때마다 최고점 확인 및 업데이트
-  useEffect(() => {
-    if (score > bestScore) {
-      setBestScore(score);
-      persistState('bestScore', score);
-    }
-    persistState('currentScore', scoreRef.current);
-  }, [score, bestScore, setBestScore]);
-
-  // 점수판 유지
-  useEffect(() => {
-    persistState('grid', grid);
-  }, [grid]);
-
-  // 게임 종료 및 승리 확인
-  const isGameOver = gameOver(grid);
-  const isGameWon = gameWon(grid);
-
-  const handleKeyPressCallback = useCallback(
-    (e: KeyboardEvent) => {
-      handleKeyPress(
-        e,
-        grid,
-        setGrid,
-        setHistory,
-        history,
-        scoreRef,
-        setScore,
-        isGameOver,
-        isGameWon,
-      );
-    },
-    [grid, history, isGameOver, isGameWon, setGrid, setHistory, setScore],
-  );
-
-  useEffect(() => {
-    window.addEventListener('keydown', handleKeyPressCallback);
-    return () => {
-      window.removeEventListener('keydown', handleKeyPressCallback);
-    };
-  }, [handleKeyPressCallback]);
+  const { grid, score, bestScore, isGameOver, isGameWon, resetGame, undo } =
+    useGame();
 
   return (
     <div className="Wrapper">
       <Title score={score} bestScore={bestScore} />
       <div className="game-container">
-        <BoardHeader resetGame={resetGameCallback} undo={undoCallback} />
+        <BoardHeader resetGame={resetGame} undo={undo} />
         <Board grid={grid} />
-        {isGameOver && (
-          <Overlay message="Game Over!" resetGame={resetGameCallback} />
-        )}
-        {isGameWon && (
-          <Overlay message="You Win!" resetGame={resetGameCallback} />
-        )}
+        {isGameOver && <Overlay message="Game Over!" resetGame={resetGame} />}
+        {isGameWon && <Overlay message="You Win!" resetGame={resetGame} />}
       </div>
     </div>
   );
@@ -109,117 +37,22 @@ function App() {
 
 export default App;
 
-// callbacks
+type PrevState = {
+  grid: number[][];
+  score: number;
+};
 
-export const persistState = (
+const persistState = (
   key: string,
   value: object | string | number | boolean | null,
 ) => {
   localStorage.setItem(key, JSON.stringify(value));
 };
 
-export const resetGame = (
-  setGrid: (grid: number[][]) => void,
-  scoreRef: MutableRefObject<number>,
-  setScore: (score: number) => void,
-  setHistory: (history: PrevState[]) => void,
-) => {
-  const newGrid = initializeGrid();
-  setGrid(newGrid);
-  scoreRef.current = 0;
-  setScore(0);
-  setHistory([]);
-  persistState('previousState', { grid: [], score: 0 });
-  persistState('grid', newGrid);
-};
-
-export const undo = (
-  history: PrevState[],
-  setGrid: (grid: number[][]) => void,
-  setScore: (score: number) => void,
-  scoreRef: MutableRefObject<number>,
-  setHistory: (history: PrevState[]) => void,
-) => {
-  if (history.length === 0) return;
-
-  const previousState = history[history.length - 1];
-  if (previousState === undefined) return;
-
-  setGrid(previousState.grid);
-  setScore(previousState.score);
-  scoreRef.current = previousState.score;
-
-  const newHistory = history.slice(0, -1);
-  setHistory(newHistory);
-  persistState('history', newHistory);
-  persistState('grid', previousState.grid);
-  persistState('currentScore', previousState.score);
-};
-
-export const handleKeyPress = (
-  e: KeyboardEvent,
-  grid: number[][],
-  setGrid: (grid: number[][]) => void,
-  setHistory: (history: React.SetStateAction<PrevState[]>) => void,
-  history: PrevState[],
-  scoreRef: MutableRefObject<number>,
-  setScore: (score: number) => void,
-  isGameOver: boolean,
-  isGameWon: boolean,
-) => {
-  if (isGameOver || isGameWon) return;
-
-  let moved = false;
-  let currentGrid = grid;
-  let scoreToAdd = 0;
-
-  //undo 을 위한 grid 및 점수 저장
-  setHistory((prevHistory) => [
-    ...prevHistory,
-    {
-      grid: JSON.parse(JSON.stringify(grid)) as number[][],
-      score: scoreRef.current,
-    },
-  ]);
-
-  persistState('history', [
-    ...history,
-    {
-      grid: JSON.parse(JSON.stringify(grid)) as number[][],
-      score: scoreRef.current,
-    },
-  ]);
-
-  switch (e.key) {
-    case 'ArrowUp':
-      [currentGrid, moved, scoreToAdd] = moveUp(currentGrid);
-      break;
-    case 'ArrowDown':
-      [currentGrid, moved, scoreToAdd] = moveDown(currentGrid);
-      break;
-    case 'ArrowLeft':
-      [currentGrid, moved, scoreToAdd] = moveLeft(currentGrid);
-      break;
-    case 'ArrowRight':
-      [currentGrid, moved, scoreToAdd] = moveRight(currentGrid);
-      break;
-    default:
-      return;
-  }
-
-  if (moved) {
-    currentGrid = addTile(currentGrid);
-    setGrid(currentGrid);
-
-    scoreRef.current += scoreToAdd;
-    setScore(scoreRef.current);
-  }
-};
-
-function usePersistedState<T>(
+const usePersistedState = <T,>(
   key: string,
   initialValue: T,
-): [T, React.Dispatch<React.SetStateAction<T>>] {
+): [T, React.Dispatch<React.SetStateAction<T>>] => {
   const [state, setState] = useState<T>(() => {
     const persistedValue = localStorage.getItem(key);
     return persistedValue !== null
@@ -232,4 +65,133 @@ function usePersistedState<T>(
   }, [key, state]);
 
   return [state, setState];
-}
+};
+
+type GameState = {
+  grid: number[][];
+  score: number;
+  bestScore: number;
+  isGameOver: boolean;
+  isGameWon: boolean;
+  resetGame: () => void;
+  undo: () => void;
+};
+
+const useGame = (): GameState => {
+  const [grid, setGrid] = usePersistedState('grid', initializeGrid());
+  const [score, setScore] = usePersistedState('currentScore', 0);
+  const [bestScore, setBestScore] = usePersistedState('bestScore', 0);
+  const [history, setHistory] = usePersistedState<PrevState[]>('history', []);
+
+  const scoreRef = useRef<number>(score);
+
+  const isGameOver = gameOver(grid);
+  const isGameWon = gameWon(grid);
+
+  useEffect(() => {
+    if (score > bestScore) {
+      setBestScore(score);
+      persistState('bestScore', score);
+    }
+    persistState('currentScore', scoreRef.current);
+  }, [score, bestScore, setBestScore]);
+
+  useEffect(() => {
+    persistState('grid', grid);
+  }, [grid]);
+
+  const handleKeyPress = useCallback(
+    (e: KeyboardEvent) => {
+      if (isGameOver || isGameWon) return;
+
+      let moved = false;
+      let currentGrid = grid;
+      let scoreToAdd = 0;
+
+      setHistory((prevHistory) => [
+        ...prevHistory,
+        {
+          grid: JSON.parse(JSON.stringify(grid)) as number[][],
+          score: scoreRef.current,
+        },
+      ]);
+
+      persistState('history', [
+        ...history,
+        {
+          grid: JSON.parse(JSON.stringify(grid)) as number[][],
+          score: scoreRef.current,
+        },
+      ]);
+
+      switch (e.key) {
+        case 'ArrowUp':
+          [currentGrid, moved, scoreToAdd] = moveUp(currentGrid);
+          break;
+        case 'ArrowDown':
+          [currentGrid, moved, scoreToAdd] = moveDown(currentGrid);
+          break;
+        case 'ArrowLeft':
+          [currentGrid, moved, scoreToAdd] = moveLeft(currentGrid);
+          break;
+        case 'ArrowRight':
+          [currentGrid, moved, scoreToAdd] = moveRight(currentGrid);
+          break;
+        default:
+          return;
+      }
+
+      if (moved) {
+        currentGrid = addTile(currentGrid);
+        setGrid(currentGrid);
+        scoreRef.current += scoreToAdd;
+        setScore(scoreRef.current);
+      }
+    },
+    [grid, history, isGameOver, isGameWon, setGrid, setHistory, setScore],
+  );
+
+  const resetGame = useCallback(() => {
+    const newGrid = initializeGrid();
+    setGrid(newGrid);
+    scoreRef.current = 0;
+    setScore(0);
+    setHistory([]);
+    persistState('previousState', { grid: [], score: 0 });
+    persistState('grid', newGrid);
+  }, [setGrid, setScore, setHistory]);
+
+  const undo = useCallback(() => {
+    if (history.length === 0) return;
+
+    const previousState = history[history.length - 1];
+    if (previousState === undefined) return;
+
+    setGrid(previousState.grid);
+    setScore(previousState.score);
+    scoreRef.current = previousState.score;
+
+    const newHistory = history.slice(0, -1);
+    setHistory(newHistory);
+    persistState('history', newHistory);
+    persistState('grid', previousState.grid);
+    persistState('currentScore', previousState.score);
+  }, [history, setGrid, setScore, setHistory]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyPress);
+    return () => {
+      window.removeEventListener('keydown', handleKeyPress);
+    };
+  }, [handleKeyPress]);
+
+  return {
+    grid,
+    score,
+    bestScore,
+    isGameOver,
+    isGameWon,
+    resetGame,
+    undo,
+  };
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,18 +102,18 @@ const useGame = (): GameState => {
 
   const getGameLogicForKey = (
     key: string,
-  ): [(grid: number[][]) => [number[][], boolean, number], boolean] => {
+  ): ((grid: number[][]) => [number[][], boolean, number]) | null => {
     switch (key) {
       case 'ArrowUp':
-        return [moveUp, true];
+        return moveUp;
       case 'ArrowDown':
-        return [moveDown, true];
+        return moveDown;
       case 'ArrowLeft':
-        return [moveLeft, true];
+        return moveLeft;
       case 'ArrowRight':
-        return [moveRight, true];
+        return moveRight;
       default:
-        return [moveUp, false]; // Default case, won't be used due to early return
+        return null;
     }
   };
 
@@ -121,8 +121,8 @@ const useGame = (): GameState => {
     (e: KeyboardEvent) => {
       if (isGameOver || isGameWon) return;
 
-      const [moveFunction, isValidKey] = getGameLogicForKey(e.key);
-      if (!isValidKey) return;
+      const moveFunction = getGameLogicForKey(e.key);
+      if (moveFunction === null) return;
 
       setHistory((prevHistory) => [
         ...prevHistory,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,13 +100,29 @@ const useGame = (): GameState => {
     persistState('grid', grid);
   }, [grid]);
 
+  const getGameLogicForKey = (
+    key: string,
+  ): [(grid: number[][]) => [number[][], boolean, number], boolean] => {
+    switch (key) {
+      case 'ArrowUp':
+        return [moveUp, true];
+      case 'ArrowDown':
+        return [moveDown, true];
+      case 'ArrowLeft':
+        return [moveLeft, true];
+      case 'ArrowRight':
+        return [moveRight, true];
+      default:
+        return [moveUp, false]; // Default case, won't be used due to early return
+    }
+  };
+
   const handleKeyPress = useCallback(
     (e: KeyboardEvent) => {
       if (isGameOver || isGameWon) return;
 
-      let moved = false;
-      let currentGrid = grid;
-      let scoreToAdd = 0;
+      const [moveFunction, isValidKey] = getGameLogicForKey(e.key);
+      if (!isValidKey) return;
 
       setHistory((prevHistory) => [
         ...prevHistory,
@@ -124,26 +140,11 @@ const useGame = (): GameState => {
         },
       ]);
 
-      switch (e.key) {
-        case 'ArrowUp':
-          [currentGrid, moved, scoreToAdd] = moveUp(currentGrid);
-          break;
-        case 'ArrowDown':
-          [currentGrid, moved, scoreToAdd] = moveDown(currentGrid);
-          break;
-        case 'ArrowLeft':
-          [currentGrid, moved, scoreToAdd] = moveLeft(currentGrid);
-          break;
-        case 'ArrowRight':
-          [currentGrid, moved, scoreToAdd] = moveRight(currentGrid);
-          break;
-        default:
-          return;
-      }
+      const [currentGrid, moved, scoreToAdd] = moveFunction(grid);
 
       if (moved) {
-        currentGrid = addTile(currentGrid);
-        setGrid(currentGrid);
+        const newGrid = addTile(currentGrid);
+        setGrid(newGrid);
         scoreRef.current += scoreToAdd;
         setScore(scoreRef.current);
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,14 +91,9 @@ const useGame = (): GameState => {
   useEffect(() => {
     if (score > bestScore) {
       setBestScore(score);
-      persistState('bestScore', score);
     }
     persistState('currentScore', scoreRef.current);
   }, [score, bestScore, setBestScore]);
-
-  useEffect(() => {
-    persistState('grid', grid);
-  }, [grid]);
 
   const getGameLogicForKey = (
     key: string,
@@ -132,14 +127,6 @@ const useGame = (): GameState => {
         },
       ]);
 
-      persistState('history', [
-        ...history,
-        {
-          grid: JSON.parse(JSON.stringify(grid)) as number[][],
-          score: scoreRef.current,
-        },
-      ]);
-
       const [currentGrid, moved, scoreToAdd] = moveFunction(grid);
 
       if (moved) {
@@ -149,7 +136,7 @@ const useGame = (): GameState => {
         setScore(scoreRef.current);
       }
     },
-    [grid, history, isGameOver, isGameWon, setGrid, setHistory, setScore],
+    [grid, isGameOver, isGameWon, setGrid, setHistory, setScore],
   );
 
   const resetGame = useCallback(() => {
@@ -158,8 +145,6 @@ const useGame = (): GameState => {
     scoreRef.current = 0;
     setScore(0);
     setHistory([]);
-    persistState('previousState', { grid: [], score: 0 });
-    persistState('grid', newGrid);
   }, [setGrid, setScore, setHistory]);
 
   const undo = useCallback(() => {
@@ -174,9 +159,6 @@ const useGame = (): GameState => {
 
     const newHistory = history.slice(0, -1);
     setHistory(newHistory);
-    persistState('history', newHistory);
-    persistState('grid', previousState.grid);
-    persistState('currentScore', previousState.score);
   }, [history, setGrid, setScore, setHistory]);
 
   useEffect(() => {

--- a/src/utils/gameLogic.tsx
+++ b/src/utils/gameLogic.tsx
@@ -1,3 +1,4 @@
+//gameLogic.tsx
 type Grid = number[][];
 export const initializeGrid = () => {
   //0 으로 채워진 4X4 grid

--- a/src/utils/gameLogic.tsx
+++ b/src/utils/gameLogic.tsx
@@ -65,7 +65,7 @@ export const moveLeft = (grid: Grid): [Grid, boolean, number] => {
       shiftedRow.push(0);
     }
 
-    // tile 음직임 check
+    // tile 움직임 check
     if (!moved && !row.every((cell, index) => cell === shiftedRow[index])) {
       moved = true;
     }


### PR DESCRIPTION
**1.  useCallback을 활용한 useGame Hook으로 리팩토링**

App 컴포넌트 내에서 useCallback으로 작성된 함수들을 useGame Hook으로 분리했습니다.
이를 통해 App 컴포넌트는 presentation만 다루고, 게임 로직은 별도의 모듈에서 처리할 수 있게 되었습니다.
가독성이 개선되었을 뿐만 아니라, 단위 테스트 시 isGameOver, isGameWon 구현의 정확성과 상관없이 App 컴포넌트 자체만 독립적으로 테스트할 수 있는 구조를 만들었습니다.
```typescript
  const { grid, score, bestScore, isGameOver, isGameWon, resetGame, undo } =
    useGame();
```

**2.  localStorage 로직을 usePersistedState Hook으로 대체**

기존 코드에서는 localStorage 값을 사용할 때마다 상태 변경 로직을 따로 작성해야 했습니다.
동일한 작업을 위해 두 가지를 수정해야 하는 구조는 유지보수성을 저해하므로, 이를 개선했습니다.
usePersistedState Hook을 활용하여 localStorage와 state 관리 로직을 통합하고, 더 간결하고 관리하기 쉬운 코드를 작성했습니다.

SNUTT 프로젝트에서 사용했던 repository 패턴을 적용하는 것도 고려했지만, 이 프로젝트 규모에서는 과도한 최적화라고 판단했습니다.
아래는 구현한 usePersistedState Hook입니다:

```typescript
const usePersistedState = <T,>(
  key: string,
  initialValue: T,
): [T, React.Dispatch<React.SetStateAction<T>>] => {
  const [state, setState] = useState<T>(() => {
    const persistedValue = localStorage.getItem(key);
    return persistedValue !== null
      ? (JSON.parse(persistedValue) as T)
      : initialValue;
  });

  useEffect(() => {
    localStorage.setItem(key, JSON.stringify(state));
  }, [key, state]);

  return [state, setState];
};
```

**리팩토링 후 발견한 불필요한 코드**
이 과정에서 아래 코드가 더 이상 필요하지 않음을 확인했습니다:
```typescript
persistState('previousState', { grid: [], score: 0 });
```

**3. 키 입력에 따른 게임 로직 분리 (getGameLogicForKey)**

키 입력에 따라 어떤 게임 로직을 사용할지 결정하는 부분을 handleKeyPress에서 분리하여 getGameLogicForKey 함수로 추출했습니다.
이를 통해 **관심사의 분리(Separation of Concerns)**를 달성했고, handleKeyPress는 키 입력 처리에만 집중할 수 있도록 개선했습니다.

```typescript
  const getGameLogicForKey = (
    key: string,
  ): ((grid: number[][]) => [number[][], boolean, number]) | null => {
    switch (key) {
      case 'ArrowUp':
        return moveUp;
      case 'ArrowDown':
        return moveDown;
      case 'ArrowLeft':
        return moveLeft;
      case 'ArrowRight':
        return moveRight;
      default:
        return null;
    }
  };

```

